### PR TITLE
Fix a concurrency bug

### DIFF
--- a/consistent.go
+++ b/consistent.go
@@ -49,7 +49,6 @@ type Consistent struct {
 	sortedHashes     uints
 	NumberOfReplicas int
 	count            int64
-	scratch          [64]byte
 	sync.RWMutex
 }
 
@@ -183,8 +182,9 @@ func (c *Consistent) GetTwo(name string) (string, string, error) {
 
 func (c *Consistent) hashKey(key string) uint32 {
 	if len(key) < 64 {
-		copy(c.scratch[:], key)
-		return crc32.ChecksumIEEE(c.scratch[:len(key)])
+		var scratch [64]byte
+		copy(scratch[:], key)
+		return crc32.ChecksumIEEE(scratch[:len(key)])
 	}
 	return crc32.ChecksumIEEE([]byte(key))
 }


### PR DESCRIPTION
Because Consistent's scratch field was only protected by a
read lock, it was possible for two goroutines to try to hash
a key and write to scratch at the same time, producing the
wrong hash.

I've removed it from the Consistent struct and put it into the
function. Because of escape analysis, it is allocated on the
stack and still avoids a heap allocation. Run BenchmarkMalloc
or examine the assembly to verify.
