### PR TITLE
Remove import comment to fix build error

### DIFF
--- a/consistent.go
+++ b/consistent.go
@@ -18,7 +18,7 @@
 //
 // Read more about consistent hashing on wikipedia:  http://en.wikipedia.org/wiki/Consistent_hashing
 //
-package consistent // import "stathat.com/c/consistent"
+package consistent
 
 import (
 	"errors"


### PR DESCRIPTION
I got the following error before removing comment.

```
can't load package: package github.com/stathat/consistent: code in
directory /Users/myusername/gocode/src/github.com/stathat/consistent
expects import "stathat.com/c/consistent"
```

I tried to build `consitent` with go 1.5.1 darwin/amd64.

```
$ go version
go version go1.5.1 darwin/amd64
```