### PR TITLE
Use absolute import instead of relative import

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,9 +5,9 @@
 package consistent_test
 
 import (
-	"../consistent"
 	"fmt"
 	"log"
+	"stathat.com/c/consistent"
 )
 
 func ExampleNew() {


### PR DESCRIPTION
Relative imports are technically permitted by the Go toolchain, but they can cause issues, and [dep doesn't support them](https://github.com/golang/dep/issues/899#issuecomment-317904001). In this example file, an absolute import works just as well, which allows projects using dep to import this package.